### PR TITLE
Revert zac.is-a.dev site URL change

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 
 export default defineConfig({
-  site: 'https://zac.is-a.dev',
+  site: 'https://zacharyfmarion.github.io',
   integrations: [mdx(), react()],
   output: 'static',
 });


### PR DESCRIPTION
## Summary
- revert the Astro `site` URL back to `https://zacharyfmarion.github.io`
- keep the repo aligned with the rolled-back Pages custom domain

## Testing
- yarn build
